### PR TITLE
Updating standard output for Transform

### DIFF
--- a/src/app/shared/services/dpsplus.service.ts
+++ b/src/app/shared/services/dpsplus.service.ts
@@ -95,7 +95,7 @@ export class DpsPlusService {
     //Output: Power output over charge time cycle for both moves and cycle time
 
     if (quickNameTypeStats.name == 'Transform') { // transform is a quick move that is irrelevant for DPS and breaks some calculations, so we just return with 0 power
-      return [0, 0, 1000];
+      return [0, 0, 1000, 1000, 0];
     }
 
     //Calculating the charge time to use the charge move


### PR DESCRIPTION
Since I changed the output of the getMovesetPower function, I added two more outputs for transform to ensure nothing is divided by zero.